### PR TITLE
Allow use of statically allocated buffers

### DIFF
--- a/src/ACAN2515.cpp
+++ b/src/ACAN2515.cpp
@@ -317,17 +317,32 @@ uint16_t ACAN2515::internalBeginOperation (const ACAN2515Settings & inSettings,
     errorCode |= kInconsistentBitRateSettings ;
   }
 //----------------------------------- Allocate buffer
-  if (!mReceiveBuffer.initWithSize (inSettings.mReceiveBufferSize)) {
-    errorCode |= kCannotAllocateReceiveBuffer ;
-  }
-  if (!mTransmitBuffer [0].initWithSize (inSettings.mTransmitBuffer0Size)) {
-    errorCode |= kCannotAllocateTransmitBuffer0 ;
-  }
-  if (!mTransmitBuffer [1].initWithSize (inSettings.mTransmitBuffer1Size)) {
-    errorCode |= kCannotAllocateTransmitBuffer1 ;
-  }
-  if (!mTransmitBuffer [2].initWithSize (inSettings.mTransmitBuffer2Size)) {
-    errorCode |= kCannotAllocateTransmitBuffer2 ;
+  if (inSettings.mReceiveAndTxBuffersStatic) {
+    if (!mReceiveBuffer.initWithStaticSize (inSettings.mReceiveBuffer, inSettings.mReceiveBufferSize)) {
+      errorCode |= kCannotAllocateReceiveBuffer ;
+    }
+    if (!mTransmitBuffer [0].initWithStaticSize (inSettings.mTxb0Buffer, inSettings.mTransmitBuffer0Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer0 ;
+    }
+    if (inSettings.mTransmitBuffer1Size > 0 && !mTransmitBuffer [1].initWithStaticSize (inSettings.mTxb1Buffer, inSettings.mTransmitBuffer1Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer1 ;
+    }
+    if (inSettings.mTransmitBuffer2Size > 0 && !mTransmitBuffer [2].initWithStaticSize (inSettings.mTxb2Buffer, inSettings.mTransmitBuffer2Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer2 ;
+    }
+  } else {
+    if (!mReceiveBuffer.initWithSize (inSettings.mReceiveBufferSize)) {
+      errorCode |= kCannotAllocateReceiveBuffer ;
+    }
+    if (!mTransmitBuffer [0].initWithSize (inSettings.mTransmitBuffer0Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer0 ;
+    }
+    if (!mTransmitBuffer [1].initWithSize (inSettings.mTransmitBuffer1Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer1 ;
+    }
+    if (!mTransmitBuffer [2].initWithSize (inSettings.mTransmitBuffer2Size)) {
+      errorCode |= kCannotAllocateTransmitBuffer2 ;
+    }
   }
   mTXBIsFree [0] = true ;
   mTXBIsFree [1] = true ;

--- a/src/ACAN2515Settings.h
+++ b/src/ACAN2515Settings.h
@@ -10,6 +10,9 @@
 
 #include <stdint.h>
 
+
+class CANMessage ;
+
 //··································································································
 
 class ACAN2515Settings {
@@ -155,6 +158,15 @@ class ACAN2515Settings {
 
   public: uint16_t CANBitSettingConsistency (void) const ;
 
+//··································································································
+//    Static buffer allocation
+//··································································································
+
+  public: bool mReceiveAndTxBuffersStatic = false ;
+  public: CANMessage * mReceiveBuffer = nullptr ;
+  public: CANMessage * mTxb0Buffer = nullptr ;
+  public: CANMessage * mTxb1Buffer = nullptr ;
+  public: CANMessage * mTxb2Buffer = nullptr ;
 
 //··································································································
 //    Constants returned by CANBitSettingConsistency

--- a/src/ACAN2515_Buffer16.h
+++ b/src/ACAN2515_Buffer16.h
@@ -19,7 +19,8 @@ class ACAN2515_Buffer16 {
   mSize (0),
   mReadIndex (0),
   mCount (0),
-  mPeakCount (0) {
+  mPeakCount (0),
+  mDynamicAllocate (true) {
   }
 
   //································································································
@@ -27,7 +28,9 @@ class ACAN2515_Buffer16 {
   //································································································
 
   public: ~ ACAN2515_Buffer16 (void) {
-    delete [] mBuffer ;
+    if (mDynamicAllocate) {
+      delete [] mBuffer ;
+    }
   }
 
   //································································································
@@ -39,6 +42,7 @@ class ACAN2515_Buffer16 {
   private: uint16_t mReadIndex ;
   private: uint16_t mCount ;
   private: uint16_t mPeakCount ; // > mSize if overflow did occur
+  private: bool mDynamicAllocate ;
 
   //································································································
   // Accessors
@@ -54,13 +58,34 @@ class ACAN2515_Buffer16 {
   //································································································
 
   public: bool initWithSize (const uint16_t inSize) {
-    delete [] mBuffer ;
+    if (mDynamicAllocate) {
+      delete [] mBuffer ;
+    }
     mBuffer = new CANMessage [inSize] ;
     const bool ok = mBuffer != NULL ;
     mSize = ok ? inSize : 0 ;
     mReadIndex = 0 ;
     mCount = 0 ;
     mPeakCount = 0 ;
+    mDynamicAllocate = true;
+    return ok ;
+  }
+
+  //································································································
+  // initWithStaticSize
+  //································································································
+
+  public: bool initWithStaticSize (CANMessage * buffer, const uint16_t inSize) {
+    if (mDynamicAllocate) {
+      delete [] mBuffer ;
+    }
+    mBuffer = buffer ;
+    const bool ok = mBuffer != NULL ;
+    mSize = ok ? inSize : 0 ;
+    mReadIndex = 0 ;
+    mCount = 0 ;
+    mPeakCount = 0 ;
+    mDynamicAllocate = false;
     return ok ;
   }
 
@@ -106,7 +131,9 @@ class ACAN2515_Buffer16 {
   //································································································
 
   public: void free (void) {
-    delete [] mBuffer ; mBuffer = nullptr ;
+    if (mDynamicAllocate) {
+      delete [] mBuffer ; mBuffer = nullptr ;
+    }
     mSize = 0 ;
     mReadIndex = 0 ;
     mCount = 0 ;


### PR DESCRIPTION
Allow the use of statically allocated transmit and receive buffers.

This makes it much easier to use on low-memory devices(e.g. an Uno), as if you allocate too much memory the compilation will fail instead of failing at runtime.